### PR TITLE
[reboot][asan] stop asan-enabled containers on reboot

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -25,6 +25,7 @@ REBOOT_USER=$(logname)
 PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 SUBTYPE=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype)
+ASAN=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asan)
 VERBOSE=no
 EXIT_NEXT_IMAGE_NOT_EXISTS=4
 EXIT_SONIC_INSTALLER_VERIFY_REBOOT=21
@@ -76,6 +77,17 @@ function stop_sonic_services()
         sleep 3
     fi
     stop_pmon_service
+}
+
+function stop_services_asan()
+{
+    if [[ x"$ASIC_TYPE" == x"mellanox" ]]; then
+        debug "Stopping syncd for ASAN"
+        systemctl stop syncd
+    fi
+
+    debug "Stopping swss for ASAN"
+    systemctl stop swss
 }
 
 function clear_warm_boot()
@@ -186,6 +198,11 @@ tag_images
 
 # Stop SONiC services gracefully.
 stop_sonic_services
+
+# Stop ASAN-enabled services so the report can be generated
+if [[ x"$ASAN" == x"yes" ]]; then
+    stop_services_asan
+fi
 
 clear_warm_boot
 


### PR DESCRIPTION
This will make the relevant processes receive SIGTERM and generate the
reports.
The behavior of regular (ENABLE_ASAN=n) images is not affected.

#### What I did
Modified the reboot script so the asan logs are generated on reboot.
#### How I did it
Added stop_services_asan() to reboot script.
#### How to verify it
Added "asan: 'yes'" to the /etc/sonic/sonic_version.yml
Checked that relevant containers are stopped and logs are generated 
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

