### PR TITLE
[mellanox] [db_migrator] add a migration for tunnel ecn mode

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -58,7 +58,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_202505_01'
+        self.CURRENT_VERSION = 'version_202511_01'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -935,6 +935,27 @@ class DBMigrator():
             except Exception as e:
                 log.log_error(f"Failed to migrate DHCP servers for {vlan_key}: {str(e)}")
 
+    def migrate_ipinip_tunnel_ecn_mode_mellanox(self):
+        """
+        Migrate IPINIP_TUNNEL ecn mode to copy_from_outer.
+
+        Prior to 202511, on Mellanox platform, the ecn mode of IPINIP tunnel was set to standard.
+        """
+
+        table_name = 'TUNNEL_DECAP_TABLE'
+        keys_to_migrate = [
+            'IPINIP_SUBNET',
+            'IPINIP_TUNNEL',
+            'IPINIP_SUBNET_V6',
+            'IPINIP_V6_TUNNEL'
+        ]
+
+        table = self.appDB.get_table(table_name)
+        for k, v in table.items():
+            if k in keys_to_migrate:
+                log.log_info(f"Migrating {k}, ecn mode: {v.get('ecn_mode')} -> copy_from_outer")
+                v['ecn_mode'] = 'copy_from_outer'
+                self.appDB.set_entry(table_name, k, v)
 
     def version_unknown(self):
         """
@@ -1389,6 +1410,17 @@ class DBMigrator():
             self.migrate_dhcp_servers_to_dhcpv4_relay()
 
         self.migrate_flex_counter_delay_status_removal()
+        self.set_version('version_202511_01')
+        return 'version_202511_01'
+
+    def version_202511_01(self):
+        """
+        Version 202511_01.
+        """
+        log.log_info('Handling version_202511_01')
+
+        if self.asic_type == "mellanox":
+            self.migrate_ipinip_tunnel_ecn_mode_mellanox()
         return None
 
     def get_version(self):

--- a/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_expected.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_expected.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"copy_from_outer",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_input.json
+++ b/tests/db_migrator_input/appl_db/tunnel_table_ecn_mode_input.json
@@ -1,0 +1,26 @@
+{
+    "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    },
+    "TUNNEL_DECAP_TABLE:IPINIP_SUBNET_V6" : {
+        "tunnel_type":"IPINIP",
+        "dscp_mode":"pipe",
+        "ecn_mode":"standard",
+        "ttl_mode":"pipe"
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -1224,3 +1224,36 @@ class TestDhcpv4RelayMigrator(object):
         # Verify migration was executed
         relay_entry = dbmgtr.configDB.get_entry("DHCPV4_RELAY", vlan_name)
         assert relay_entry.get("dhcpv4_servers") == [dhcp_server]
+
+
+class TestIPinIPTunnelEcnModeMigrator(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        dbconnector.dedicated_dbs['APPL_DB'] = None
+
+    def test_ipinip_tunnel_ecn_mode_migrator(self):
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_input')
+
+        device_info.get_sonic_version_info = get_sonic_version_info_mlnx
+        import db_migrator
+        dbmgtr = db_migrator.DBMigrator(None)
+        dbmgtr.migrate_ipinip_tunnel_ecn_mode_mellanox()
+
+        dbconnector.dedicated_dbs['APPL_DB'] = os.path.join(mock_db_path, 'appl_db', 'tunnel_table_ecn_mode_expected')
+        expected_appl_db = SonicV2Connector(host='127.0.0.1')
+        expected_appl_db.connect(expected_appl_db.APPL_DB)
+
+        expected_keys = sorted(expected_appl_db.keys(expected_appl_db.APPL_DB, "*"))
+        resulting_keys = sorted(dbmgtr.appDB.keys(dbmgtr.appDB.APPL_DB, "*"))
+
+        assert expected_keys == resulting_keys
+        for key in expected_keys:
+            resulting_keys = dbmgtr.appDB.get_all(dbmgtr.appDB.APPL_DB, key)
+            expected_keys = expected_appl_db.get_all(expected_appl_db.APPL_DB, key)
+            diff = DeepDiff(resulting_keys, expected_keys, ignore_order=True)
+            assert not diff


### PR DESCRIPTION
I#### What I did
In the 202511, the tunnel ECN mode for Mellanox platforms has changed from standard to copy_from_outer.
This commit adds a migration that aligns APPL_DB to this change.

#### How I did it
Added a new migration for the Mellanox platform.

#### How to verify it
New unit test, manual tests.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

