### PR TITLE
[multi-asic] fix utilities_common Db helper

### DIFF
--- a/utilities_common/db.py
+++ b/utilities_common/db.py
@@ -1,5 +1,5 @@
 from sonic_py_common import multi_asic, device_info
-from swsscommon.swsscommon import ConfigDBConnector, ConfigDBPipeConnector, SonicV2Connector
+from swsscommon.swsscommon import ConfigDBConnector, ConfigDBPipeConnector, SonicV2Connector, SonicDBConfig
 from utilities_common import constants
 from utilities_common.multi_asic import multi_asic_ns_choices
 
@@ -30,6 +30,8 @@ class Db(object):
         self.db_clients[constants.DEFAULT_NAMESPACE] = self.db
 
         if multi_asic.is_multi_asic():
+            if not SonicDBConfig.isGlobalInit():
+                SonicDBConfig.initializeGlobalConfig()
             self.ns_list = multi_asic_ns_choices()
             for ns in self.ns_list:
                 self.cfgdb_clients[ns] = (


### PR DESCRIPTION
#### What I did
This is to fix the utilities_common.Db() helper class.

Using it now in the multi-asic environment leads to an error:
```
RuntimeError: :- validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig
```

This impacts the `counterpoll switch` CLI command.

#### How I did it
Added a proper DB config initialization

#### How to verify it
* Manual test for the Db() helper
* Running counterpoll switch disable in multi-asic environment

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

